### PR TITLE
Fix for computers with python 3 as default

### DIFF
--- a/bin/collect_logs.py
+++ b/bin/collect_logs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # ./summary_logs.py log_foo.txt log_bar.txt ...
 #
 import sys

--- a/bin/gen_partition.py
+++ b/bin/gen_partition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # ./gen_partition.py hoge.snt hoge.ptn
 # generate partition file from snt file
 # usage: gen_partiton.py hoge.snt #proton #neutron parity

--- a/bin/kshell_ui.py
+++ b/bin/kshell_ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # 
 # (kshell_home_dir)/bin/kshell_ui.py 
 #    user interface to generate shell script.

--- a/bin/kshell_ui.py
+++ b/bin/kshell_ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 # 
 # (kshell_home_dir)/bin/kshell_ui.py 
 #    user interface to generate shell script.

--- a/bin/mshell2snt.py
+++ b/bin/mshell2snt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # ./mshell2snt.py hoge.sps hoge.int output.snt
 # transform  mshell/mshell64 format (p-n formalism) to snt format
 #

--- a/bin/nushell2snt.py
+++ b/bin/nushell2snt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python2
 # 
 #  ./nushell2snt.py foo.sp bar.int foobar.snt
 #   stardard output snt file for kshell

--- a/bin/shellmodelutilities.py
+++ b/bin/shellmodelutilities.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 from __future__ import division
 import numpy as np 
 # import matplotlib.pyplot as plt 


### PR DESCRIPTION
A fix where python 2.7 is used to execute the kshell_ui.py script.